### PR TITLE
Delay validation of M365 apps if MAU is running/patching

### DIFF
--- a/Validations/Microsoft Office 365.bash
+++ b/Validations/Microsoft Office 365.bash
@@ -12,6 +12,8 @@
 #
 #   Version 0.0.3, 25-Apr-2023, Andrew Clark (@drtaru)
 #   - Changed Success result to Success to map to new SYM validation status
+#   Version 0.0.4 - 13-Jun-2024, Lewis B (@master-vodawagner)
+#   - Added ability to delay whilst Microsoft AutoUpdater is running/patching apps
 #
 ####################################################################################
 # A script to collect the installation status of Microsoft Office 365.             #
@@ -32,7 +34,7 @@
 #
 ####################################################################################################
 
-# Set Apps to check, valid options are: "Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "Microsoft PowerPoint" "Microsoft Word" "OneDrive"
+# Set Apps to check, valid options are: "Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "Microsoft PowerPoint" "Microsoft Word" "OneDrive" & "Microsoft Teams"
 appsToCheck=("Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "Microsoft PowerPoint" "Microsoft Word" "OneDrive")
 appChecks=""
 RESULT=""
@@ -50,6 +52,7 @@ IFS=""
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 function appCheck() {
+
     app="${1}"
     if [[ -f "/Applications/${app}.app/Contents/Info.plist" ]]; then
         appChecks+="${app} installed; "
@@ -70,6 +73,12 @@ function appCheck() {
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Check for Microsoft Office 365 apps (i.e., Microsoft_365_and_Office_16.70.23021201_Installer.pkg)
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+#Allow Microsoft AutoUpdater to scan/patch apps before validating install
+while pgrep -a "Microsoft AutoUpdate"; do
+    echo "Microsoft AutoUpdater is still running; pausing for 10 seconds"
+    sleep 10
+done
 
 for app in ${appsToCheck[@]}; do
   appCheck "$app"

--- a/Validations/Microsoft Office 365.bash
+++ b/Validations/Microsoft Office 365.bash
@@ -34,7 +34,7 @@
 #
 ####################################################################################################
 
-# Set Apps to check, valid options are: "Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "Microsoft PowerPoint" "Microsoft Word" "OneDrive" & "Microsoft Teams"
+# Set Apps to check, valid options are: "Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "Microsoft PowerPoint" "Microsoft Word" "OneDrive"
 appsToCheck=("Microsoft Excel" "Microsoft OneNote" "Microsoft Outlook" "Microsoft PowerPoint" "Microsoft Word" "OneDrive")
 appChecks=""
 RESULT=""


### PR DESCRIPTION
Added ability to delay validation of M365 apps if Microsoft AutoUpdater is running/patching apps immediately after installation.