### PR TITLE
Fix for Issue #178

### DIFF
--- a/Setup-Your-Mac-via-Dialog.bash
+++ b/Setup-Your-Mac-via-Dialog.bash
@@ -756,8 +756,8 @@ function validatePolicyResult() {
         # (Always evaluates as: 'success' and 'Installed')
         ###
 
-        "None" | "none" | *"Blurscreen"* | *"blurscreen"* )
-
+        "None" | "none" | *"Blurscreen"* | *"blurscreen"* | *"Dialog"* | *"dialog"* )
+        
             outputLineNumberInVerboseDebugMode
             logMessage "SETUP YOUR MAC DIALOG" "Confirm Policy Execution: ${validation}"
             dialogUpdateSetupYourMac "listitem: index: $i, status: success, statustext: Installed"


### PR DESCRIPTION
Fixes the "Hide Dialog" and "Show Dialog" special validation commands so that they do appear as a validation Error if used in your provisioning.